### PR TITLE
Feat camera manager

### DIFF
--- a/src/glfw-sandbox/camera.cpp
+++ b/src/glfw-sandbox/camera.cpp
@@ -1,19 +1,19 @@
 #include "camera.hpp"
 #include "glew.h"
 
-void Camera::SetLocation(Vector3d vec) {
+void CameraManager::SetLocation(Vector3d vec) {
 	location.x = vec.x;
 	location.y = vec.y;
 	location.z = vec.z;
 }
 
-void Camera::SetTarget(Vector3d vec) {
+void CameraManager::SetTarget(Vector3d vec) {
 	target.x = vec.x;
 	target.y = vec.y;
 	target.z = vec.z;
 }
 
-void Camera::Apply() {
+void CameraManager::Apply() {
 	gluLookAt(location.x, location.y, location.z,
 			    target.x,   target.y,   target.z,
 			           0,          1,          0);

--- a/src/glfw-sandbox/camera.cpp
+++ b/src/glfw-sandbox/camera.cpp
@@ -18,3 +18,7 @@ void CameraManager::Apply() {
 			    target.x,   target.y,   target.z,
 			           0,          1,          0);
 }
+
+std::string CameraManager::GetName() const {
+	return name;
+}

--- a/src/glfw-sandbox/camera.cpp
+++ b/src/glfw-sandbox/camera.cpp
@@ -1,0 +1,20 @@
+#include "camera.hpp"
+#include "glew.h"
+
+void Camera::SetLocation(Vector3d vec) {
+	location.x = vec.x;
+	location.y = vec.y;
+	location.z = vec.z;
+}
+
+void Camera::SetTarget(Vector3d vec) {
+	target.x = vec.x;
+	target.y = vec.y;
+	target.z = vec.z;
+}
+
+void Camera::Apply() {
+	gluLookAt(location.x, location.y, location.z,
+			    target.x,   target.y,   target.z,
+			           0,          1,          0);
+}

--- a/src/glfw-sandbox/camera.hpp
+++ b/src/glfw-sandbox/camera.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "vector3d.hpp"
+
+class Camera {
+private:
+	Vector3d location{0,1.7,0};
+	Vector3d target{0,1.7,-1};
+	float fov = 60;
+public:
+
+	void SetLocation(Vector3d vec);
+
+	void SetTarget(Vector3d vec);
+
+	void Apply();
+};

--- a/src/glfw-sandbox/camera.hpp
+++ b/src/glfw-sandbox/camera.hpp
@@ -11,7 +11,7 @@ private:
 	float fov = 60;
 public:
 
-	CameraManager(Vector3d location) : location{location} {
+	CameraManager(std::string cameraName, Vector3d location) : name{cameraName}, location { location } {
 
 	}
 
@@ -20,4 +20,6 @@ public:
 	void SetTarget(Vector3d vec);
 
 	void Apply();
+
+	std::string GetName() const;
 };

--- a/src/glfw-sandbox/camera.hpp
+++ b/src/glfw-sandbox/camera.hpp
@@ -1,13 +1,19 @@
 #pragma once
 
 #include "vector3d.hpp"
+#include <string>
 
-class Camera {
+class CameraManager {
 private:
+	const std::string name;
 	Vector3d location{0,1.7,0};
 	Vector3d target{0,1.7,-1};
 	float fov = 60;
 public:
+
+	CameraManager(Vector3d location) : location{location} {
+
+	}
 
 	void SetLocation(Vector3d vec);
 

--- a/src/glfw-sandbox/controls.hpp
+++ b/src/glfw-sandbox/controls.hpp
@@ -76,5 +76,19 @@ public:
 		return false;
 	}
 
+	/*static bool keyR(GLFWwindow* window)
+	{
+		glfwSetKeyCallback(window, key_callback);
+		return false;
+	}
+
+	static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
+	{
+		if (key == GLFW_KEY_R && action == GLFW_PRESS)
+			std::cout << "R key pressed" << std::endl;
+
+
+	}*/
+
 };
 

--- a/src/glfw-sandbox/controls_static.hpp
+++ b/src/glfw-sandbox/controls_static.hpp
@@ -12,6 +12,12 @@ class ControlsStatic
 {
 private:
 
+	void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
+	{
+		//if (key == GLFW_KEY_E && action == GLFW_PRESS)
+			
+	}
+
 	
 public:
 
@@ -70,6 +76,16 @@ public:
 	{
 		int state{};
 		state = glfwGetKey(window, GLFW_KEY_T);
+		if (state == GLFW_PRESS)
+			return true;
+
+		return false;
+	}
+
+	static bool keyF(GLFWwindow* window)
+	{
+		int state{};
+		state = glfwGetKey(window, GLFW_KEY_F);
 		if (state == GLFW_PRESS)
 			return true;
 

--- a/src/glfw-sandbox/controls_static.hpp
+++ b/src/glfw-sandbox/controls_static.hpp
@@ -12,14 +12,12 @@ class ControlsStatic
 {
 private:
 
-	void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
-	{
-		//if (key == GLFW_KEY_E && action == GLFW_PRESS)
-			
-	}
+	bool test = false;
 
 	
 public:
+
+
 
 
 	static bool arrowUP(GLFWwindow* window)
@@ -86,11 +84,47 @@ public:
 	{
 		int state{};
 		state = glfwGetKey(window, GLFW_KEY_F);
-		if (state == GLFW_PRESS)
+		
+		if (state == GLFW_PRESS)	
 			return true;
-
+	
 		return false;
 	}
+
+	 static bool keyR(GLFWwindow* window)
+	{	
+		
+		glfwSetKeyCallback(window, key_callback);
+		return false;
+	}
+
+	static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
+	{
+
+		if (key == GLFW_KEY_R)
+		{
+			switch (action)
+			{
+			case GLFW_RELEASE:
+			{
+				std::cout << "R key released" << std::endl;;
+				break;
+			}
+			default:
+			{
+				//ControlsStatic::test = false;
+				break;
+
+			}
+			}
+		}
+
+
+
+	}
+	
+		
+	
 
 };
 

--- a/src/glfw-sandbox/controls_static.hpp
+++ b/src/glfw-sandbox/controls_static.hpp
@@ -12,13 +12,8 @@ class ControlsStatic
 {
 private:
 
-	bool test = false;
-
-	
+		
 public:
-
-
-
 
 	static bool arrowUP(GLFWwindow* window)
 	{
@@ -82,46 +77,19 @@ public:
 
 	static bool keyF(GLFWwindow* window)
 	{
-		int state{};
-		state = glfwGetKey(window, GLFW_KEY_F);
-		
-		if (state == GLFW_PRESS)	
-			return true;
+		static int lastState = false; // This will be initialized to false initially, but since then, it will remember the last assigned value
+
+		int state = glfwGetKey(window, GLFW_KEY_F);
+		bool pressed = (state == GLFW_PRESS and lastState == false);
+
+		lastState = state;
+
+		return pressed;
+	}
+
+
+
 	
-		return false;
-	}
-
-	 static bool keyR(GLFWwindow* window)
-	{	
-		
-		glfwSetKeyCallback(window, key_callback);
-		return false;
-	}
-
-	static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
-	{
-
-		if (key == GLFW_KEY_R)
-		{
-			switch (action)
-			{
-			case GLFW_RELEASE:
-			{
-				std::cout << "R key released" << std::endl;;
-				break;
-			}
-			default:
-			{
-				//ControlsStatic::test = false;
-				break;
-
-			}
-			}
-		}
-
-
-
-	}
 	
 		
 	

--- a/src/glfw-sandbox/glfw-sandbox.vcxproj
+++ b/src/glfw-sandbox/glfw-sandbox.vcxproj
@@ -147,15 +147,19 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="camera.cpp" />
     <ClCompile Include="frame.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="vector3d.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="camera.hpp" />
     <ClInclude Include="controls.hpp" />
     <ClInclude Include="controls_static.hpp" />
     <ClInclude Include="engine.hpp" />
     <ClInclude Include="drawings.hpp" />
     <ClInclude Include="frame.hpp" />
+    <ClInclude Include="vector3d.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/glfw-sandbox/glfw-sandbox.vcxproj.filters
+++ b/src/glfw-sandbox/glfw-sandbox.vcxproj.filters
@@ -21,6 +21,12 @@
     <ClCompile Include="frame.cpp">
       <Filter>Zdrojové soubory</Filter>
     </ClCompile>
+    <ClCompile Include="camera.cpp">
+      <Filter>Zdrojové soubory</Filter>
+    </ClCompile>
+    <ClCompile Include="vector3d.cpp">
+      <Filter>Zdrojové soubory</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="engine.hpp">
@@ -36,6 +42,12 @@
       <Filter>Zdrojové soubory</Filter>
     </ClInclude>
     <ClInclude Include="frame.hpp">
+      <Filter>Zdrojové soubory</Filter>
+    </ClInclude>
+    <ClInclude Include="camera.hpp">
+      <Filter>Zdrojové soubory</Filter>
+    </ClInclude>
+    <ClInclude Include="vector3d.hpp">
       <Filter>Zdrojové soubory</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/glfw-sandbox/main.cpp
+++ b/src/glfw-sandbox/main.cpp
@@ -24,30 +24,27 @@ int main() {
     auto window = windowObject.getWindow();
     Controls controls(window);
 
-    float time = 0;
-
-    int state = 0;
     
+        
     Frame frame{};
 
-    ;
-
-    Vector3d cameraPos[2] = { { 0, 1.7, 0 }, { 0, 1.7, 0 } };
-    Vector3d cameraDirection[2] = { { 0, 0, -1 }, { 0, 0, -1 } };
-    
-
-    CameraManager firstPersonCamera{ "first person", cameraPos[0] };
-    CameraManager thirdPersonCamera{ "third person", cameraPos[1] };
+    Vector3d cameraPos[2] = { { 0, 1.7, 0 }, { 0, 2, -5 } };
+    Vector3d cameraDirection[2] = { { 0, 0, 1 }, { 0, 0, 1 } };
 
     std::vector<CameraManager> cameras{};
-    cameras.emplace_back(firstPersonCamera);
-    cameras.emplace_back(thirdPersonCamera);
+    cameras.emplace_back("first person", cameraPos[0]);
+    cameras.emplace_back("third person", cameraPos[1]);
+
+    
 
     int activeCameraIndex = 0;
 
     float cameraAngle[2] = { 0, 0 };
 
+   
+
     double fps = 5000;
+    float time = 0;
     while (!glfwWindowShouldClose(window))
     {
         frame.Begin();
@@ -58,10 +55,10 @@ int main() {
             glLoadIdentity();
 
             // Auxiliary camera
-
-
             cameraDirection[activeCameraIndex].x = sinf(-cameraAngle[activeCameraIndex] * 0.0174533);
             cameraDirection[activeCameraIndex].z = cosf(-cameraAngle[activeCameraIndex] * 0.0174533);
+
+            auto &activeCamera = cameras[activeCameraIndex];
 
             cameras[activeCameraIndex].SetLocation(cameraPos[activeCameraIndex]);
             cameras[activeCameraIndex].SetTarget(cameraPos[activeCameraIndex] + cameraDirection[activeCameraIndex]);

--- a/src/glfw-sandbox/main.cpp
+++ b/src/glfw-sandbox/main.cpp
@@ -116,6 +116,16 @@ int main() {
                     glPopMatrix();
                 }
 
+
+                /////// Isolating for better view
+
+
+
+
+
+
+
+
                 if (ControlsStatic::keyF(window))
                 {   
                     std::cout << "Camera switch" << std::endl;
@@ -125,7 +135,18 @@ int main() {
                         activeCamera = &thirdPersonCamera;
                     else{}
                 }
+
+                if (ControlsStatic::keyR(window))
+                    std::cout << "TestRRR" << std::endl;
             
+
+
+
+
+
+                /////// Isolating for better view
+
+
                 if (controls.keyT()) {
                     glTranslatef(-1, 0, 0);
                     glRotatef(std::sin(time) * 10, 0, 0, 1);

--- a/src/glfw-sandbox/main.cpp
+++ b/src/glfw-sandbox/main.cpp
@@ -14,6 +14,7 @@
 #include "controls.hpp"
 #include "controls_static.hpp" // Testing
 #include "frame.hpp"
+#include "camera.hpp"
 
 
 int main() {
@@ -37,6 +38,13 @@ int main() {
     int state = 0;
     
     Frame frame{};
+    Camera firstPersonCamera{};
+
+    Vector3d cameraPos{ 0, 1.7, 0 };
+    Vector3d cameraDirection{ 0, 0, -1 };
+
+    float cameraAngle = 0;
+
     double fps = 5000;
     while (!glfwWindowShouldClose(window))
     {
@@ -48,9 +56,13 @@ int main() {
             glLoadIdentity();
 
             // Auxiliary camera
-            gluLookAt(cameraX, cameraY, cameraZ,    // From X, Y, Z
-                      targetX, targetY, targetZ,    // To
-                       0, 1, 0);                    // Up vector
+            cameraDirection.x = sinf(-cameraAngle * 0.0174533);
+            cameraDirection.z = cosf(-cameraAngle * 0.0174533);
+
+            firstPersonCamera.SetLocation(cameraPos);
+            firstPersonCamera.SetTarget(cameraPos + cameraDirection);
+
+            firstPersonCamera.Apply();
 
             // Rendering will go here
         
@@ -61,26 +73,22 @@ int main() {
             
                 if (ControlsStatic::arrowUP(window)) // Static control without instancing
                 {
-                    cameraZ -= 5 / fps;
-                    targetZ -= 5 / fps;
+                    cameraPos = cameraPos + (cameraDirection / fps);
                 }
             
                 if (controls.arrowDOWN()) // Controls with instancing
                 {
-                    cameraZ += 5 / fps;
-                    targetZ += 5 / fps;
+                    cameraPos = cameraPos - (cameraDirection / fps);
                 }
 
                 if (controls.arrowLEFT())
                 {
-                    cameraX -= 5 / fps;
-                    targetX -= 5 / fps;
+                   cameraAngle -= 45 / fps;
                 }
 
                 if (controls.arrowRIGHT())
                 {
-                    cameraX += 5 / fps;
-                    targetX += 5 / fps;
+                   cameraAngle += 45 / fps;
                 }
 
                 if (controls.keyC())
@@ -126,7 +134,7 @@ int main() {
         frame.End();
         fps = frame.GetFrameRate();
 
-        std::cout << "Sweet FPS: " << fps << std::endl;
+        //std::cout << "Sweet FPS: " << fps << std::endl;
     }
 
     // Proper way to deinitialize GLFW - releases context and so on

--- a/src/glfw-sandbox/main.cpp
+++ b/src/glfw-sandbox/main.cpp
@@ -32,23 +32,20 @@ int main() {
 
     ;
 
-    Vector3d cameraPos{ 0, 1.7, 0 };
-    Vector3d cameraDirection{ 0, 0, -1 };
+    Vector3d cameraPos[2] = { { 0, 1.7, 0 }, { 0, 1.7, 0 } };
+    Vector3d cameraDirection[2] = { { 0, 0, -1 }, { 0, 0, -1 } };
     
-    Vector3d cameraPos2{ 0, 1.7, 0 };
-    Vector3d cameraDirection2{ 0, 0, -1 };
 
-    CameraManager firstPersonCamera{ cameraPos };
-    CameraManager thirdPersonCamera{ cameraPos2 };
-
-    
+    CameraManager firstPersonCamera{ "first person", cameraPos[0] };
+    CameraManager thirdPersonCamera{ "third person", cameraPos[1] };
 
     std::vector<CameraManager> cameras{};
     cameras.emplace_back(firstPersonCamera);
     cameras.emplace_back(thirdPersonCamera);
 
-    CameraManager &activeCamera = cameras.at(1);
-    float cameraAngle = 0;
+    int activeCameraIndex = 0;
+
+    float cameraAngle[2] = { 0, 0 };
 
     double fps = 5000;
     while (!glfwWindowShouldClose(window))
@@ -62,27 +59,14 @@ int main() {
 
             // Auxiliary camera
 
-            if (&activeCamera == &cameras.at(0)) {
-                cameraDirection.x = sinf(-cameraAngle * 0.0174533);
-                cameraDirection.z = cosf(-cameraAngle * 0.0174533);
 
-                activeCamera.SetLocation(cameraPos2);
-                activeCamera.SetTarget(cameraPos2 + cameraDirection2);
+            cameraDirection[activeCameraIndex].x = sinf(-cameraAngle[activeCameraIndex] * 0.0174533);
+            cameraDirection[activeCameraIndex].z = cosf(-cameraAngle[activeCameraIndex] * 0.0174533);
 
-                activeCamera.Apply();
-                
-            }
-            else {
-                cameraDirection.x = sinf(-cameraAngle * 0.0174533);
-                cameraDirection.z = cosf(-cameraAngle * 0.0174533);
+            cameras[activeCameraIndex].SetLocation(cameraPos[activeCameraIndex]);
+            cameras[activeCameraIndex].SetTarget(cameraPos[activeCameraIndex] + cameraDirection[activeCameraIndex]);
 
-                activeCamera.SetLocation(cameraPos);
-                activeCamera.SetTarget(cameraPos + cameraDirection);
-
-                activeCamera.Apply();
-                
-            }
-
+            cameras[activeCameraIndex].Apply();
             
 
             // Rendering will go here
@@ -94,22 +78,22 @@ int main() {
             
                 if (ControlsStatic::arrowUP(window)) // Static control without instancing
                 {
-                    cameraPos = cameraPos + (cameraDirection / fps);
+                    cameraPos[activeCameraIndex] = cameraPos[activeCameraIndex] + (cameraDirection[activeCameraIndex] / fps);
                 }
             
                 if (controls.arrowDOWN()) // Controls with instancing
                 {
-                    cameraPos = cameraPos - (cameraDirection / fps);
+                    cameraPos[activeCameraIndex] = cameraPos[activeCameraIndex] - (cameraDirection[activeCameraIndex] / fps);
                 }
 
                 if (controls.arrowLEFT())
                 {
-                   cameraAngle -= 45 / fps;
+                   cameraAngle[activeCameraIndex] -= 45 / fps;
                 }
 
                 if (controls.arrowRIGHT())
                 {
-                   cameraAngle += 45 / fps;
+                   cameraAngle[activeCameraIndex] += 45 / fps;
                 }
 
                 if (controls.keyC())
@@ -124,13 +108,13 @@ int main() {
                
                 if (ControlsStatic::keyF(window))
                 {   
-                    
-                    std::cout << "Camera switch" << std::endl;
-                    if (&activeCamera == &cameras.at(1))
-                        auto &activeCamera = cameras.at(0);
-                    else if (&activeCamera == &cameras.at(0))
-                        auto &activeCamera = cameras.at(1);
-                    else{}
+                    activeCameraIndex++;
+
+                    if (activeCameraIndex > cameras.size() - 1) {
+                        activeCameraIndex = 0;
+                    }
+
+                    std::cout << "Camera active: " << cameras[activeCameraIndex].GetName() << std::endl;
                 }
 
                 if (controls.keyT()) {

--- a/src/glfw-sandbox/main.cpp
+++ b/src/glfw-sandbox/main.cpp
@@ -25,23 +25,24 @@ int main() {
 
     float time = 0;
 
-    float cameraX, cameraY, cameraZ;
-    float targetX, targetY, targetZ;
-
-    cameraX = 0;
-    cameraY = 1.7;
-    cameraZ = 0;
-
-    targetX = 0;
-    targetY = 1.7;
-    targetZ = -1;
     int state = 0;
     
     Frame frame{};
-    Camera firstPersonCamera{};
+
+    CameraManager *activeCamera = nullptr;
 
     Vector3d cameraPos{ 0, 1.7, 0 };
     Vector3d cameraDirection{ 0, 0, -1 };
+    
+    Vector3d cameraPos2{ 0, 1.7, 0 };
+    Vector3d cameraDirection2{ 0, 0, -1 };
+
+    CameraManager firstPersonCamera{ cameraPos };
+    CameraManager thirdPersonCamera{ cameraPos2 };
+
+    activeCamera = &firstPersonCamera;
+
+    
 
     float cameraAngle = 0;
 
@@ -56,13 +57,29 @@ int main() {
             glLoadIdentity();
 
             // Auxiliary camera
-            cameraDirection.x = sinf(-cameraAngle * 0.0174533);
-            cameraDirection.z = cosf(-cameraAngle * 0.0174533);
 
-            firstPersonCamera.SetLocation(cameraPos);
-            firstPersonCamera.SetTarget(cameraPos + cameraDirection);
+            if (activeCamera == &thirdPersonCamera) {
+                cameraDirection.x = sinf(-cameraAngle * 0.0174533);
+                cameraDirection.z = cosf(-cameraAngle * 0.0174533);
 
-            firstPersonCamera.Apply();
+                activeCamera->SetLocation(cameraPos2);
+                activeCamera->SetTarget(cameraPos2 + cameraDirection2);
+
+                activeCamera->Apply();
+                
+            }
+            else {
+                cameraDirection.x = sinf(-cameraAngle * 0.0174533);
+                cameraDirection.z = cosf(-cameraAngle * 0.0174533);
+
+                activeCamera->SetLocation(cameraPos);
+                activeCamera->SetTarget(cameraPos + cameraDirection);
+
+                activeCamera->Apply();
+                
+            }
+
+            
 
             // Rendering will go here
         
@@ -97,6 +114,16 @@ int main() {
                     glTranslatef(0, 0, 1);
                     DrawObjects::wheel(8); // calling a static function
                     glPopMatrix();
+                }
+
+                if (ControlsStatic::keyF(window))
+                {   
+                    std::cout << "Camera switch" << std::endl;
+                    if (activeCamera == &thirdPersonCamera)
+                        activeCamera = &firstPersonCamera;
+                    else if (activeCamera == &firstPersonCamera)
+                        activeCamera = &thirdPersonCamera;
+                    else{}
                 }
             
                 if (controls.keyT()) {

--- a/src/glfw-sandbox/main.cpp
+++ b/src/glfw-sandbox/main.cpp
@@ -15,6 +15,7 @@
 #include "controls_static.hpp" // Testing
 #include "frame.hpp"
 #include "camera.hpp"
+#include <vector>
 
 
 int main() {
@@ -29,7 +30,7 @@ int main() {
     
     Frame frame{};
 
-    CameraManager *activeCamera = nullptr;
+    ;
 
     Vector3d cameraPos{ 0, 1.7, 0 };
     Vector3d cameraDirection{ 0, 0, -1 };
@@ -40,10 +41,13 @@ int main() {
     CameraManager firstPersonCamera{ cameraPos };
     CameraManager thirdPersonCamera{ cameraPos2 };
 
-    activeCamera = &firstPersonCamera;
-
     
 
+    std::vector<CameraManager> cameras{};
+    cameras.emplace_back(firstPersonCamera);
+    cameras.emplace_back(thirdPersonCamera);
+
+    CameraManager &activeCamera = cameras.at(1);
     float cameraAngle = 0;
 
     double fps = 5000;
@@ -58,24 +62,24 @@ int main() {
 
             // Auxiliary camera
 
-            if (activeCamera == &thirdPersonCamera) {
+            if (&activeCamera == &cameras.at(0)) {
                 cameraDirection.x = sinf(-cameraAngle * 0.0174533);
                 cameraDirection.z = cosf(-cameraAngle * 0.0174533);
 
-                activeCamera->SetLocation(cameraPos2);
-                activeCamera->SetTarget(cameraPos2 + cameraDirection2);
+                activeCamera.SetLocation(cameraPos2);
+                activeCamera.SetTarget(cameraPos2 + cameraDirection2);
 
-                activeCamera->Apply();
+                activeCamera.Apply();
                 
             }
             else {
                 cameraDirection.x = sinf(-cameraAngle * 0.0174533);
                 cameraDirection.z = cosf(-cameraAngle * 0.0174533);
 
-                activeCamera->SetLocation(cameraPos);
-                activeCamera->SetTarget(cameraPos + cameraDirection);
+                activeCamera.SetLocation(cameraPos);
+                activeCamera.SetTarget(cameraPos + cameraDirection);
 
-                activeCamera->Apply();
+                activeCamera.Apply();
                 
             }
 
@@ -117,35 +121,17 @@ int main() {
                 }
 
 
-                /////// Isolating for better view
-
-
-
-
-
-
-
-
+               
                 if (ControlsStatic::keyF(window))
                 {   
+                    
                     std::cout << "Camera switch" << std::endl;
-                    if (activeCamera == &thirdPersonCamera)
-                        activeCamera = &firstPersonCamera;
-                    else if (activeCamera == &firstPersonCamera)
-                        activeCamera = &thirdPersonCamera;
+                    if (&activeCamera == &cameras.at(1))
+                        auto &activeCamera = cameras.at(0);
+                    else if (&activeCamera == &cameras.at(0))
+                        auto &activeCamera = cameras.at(1);
                     else{}
                 }
-
-                if (ControlsStatic::keyR(window))
-                    std::cout << "TestRRR" << std::endl;
-            
-
-
-
-
-
-                /////// Isolating for better view
-
 
                 if (controls.keyT()) {
                     glTranslatef(-1, 0, 0);

--- a/src/glfw-sandbox/vector3d.cpp
+++ b/src/glfw-sandbox/vector3d.cpp
@@ -1,0 +1,17 @@
+#include "vector3d.hpp"
+
+#include <cmath>
+
+Vector3d Vector3d::operator+ (const Vector3d& other) {
+	return Vector3d{ x + other.x, y + other.y, z + other.z };
+}
+
+Vector3d Vector3d::operator- (const Vector3d& other) {
+	return Vector3d{ x - other.x, y - other.y, z - other.z };
+}
+
+Vector3d Vector3d::operator/ (float div) {
+	float vectorLength = std::cbrt(x * x + y * y + z * z);
+
+	return Vector3d{ x / vectorLength * 1 / div, y / vectorLength * 1 / div, z / vectorLength * 1 / div };
+}

--- a/src/glfw-sandbox/vector3d.hpp
+++ b/src/glfw-sandbox/vector3d.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cmath>
+
+class Vector3d {
+public:
+	float x;
+	float y;
+	float z;
+
+	Vector3d(float x, float y, float z) : x{ x }, y{ y }, z{ z } {
+	}
+
+	Vector3d operator+ (const Vector3d& other);
+
+	Vector3d operator- (const Vector3d& other);
+
+	Vector3d operator/ (float div);
+};


### PR DESCRIPTION
I fell in a deadly trap comrades, the black hole of traps, the one you cannot escape... 

:D 

Alright, so, I wanted to create a second camera, a fixed one which would not affect the first one meaning if you move while in second (fixed) camera mode any movement will be registered. Kinda achieved that via pointers and works fine but switching to it is a different matter.

The keyboard needs to have a wrapper which would capture the different state (GLFW_RELEASE) to properly simulate the camera switch like in most games when key C is pressed.